### PR TITLE
Install PTE apps and run codeunits

### DIFF
--- a/Cloud/2. Select Multi Environment.ps1
+++ b/Cloud/2. Select Multi Environment.ps1
@@ -1,6 +1,6 @@
 # Get list of active 4PS environments
 $title = "Environment Selection"
-$namefilter = "VWB"
+$namefilter = ""
 $question = "Do you want to use all active Sandbox or Production environments?"
 $choices = New-Object Collections.ObjectModel.Collection[Management.Automation.Host.ChoiceDescription]
 $choices.Add((New-Object Management.Automation.Host.ChoiceDescription -ArgumentList '&1 - Sandbox'))

--- a/Cloud/AdminCenter API/3. Install Global App updates.ps1
+++ b/Cloud/AdminCenter API/3. Install Global App updates.ps1
@@ -15,7 +15,7 @@ if ($decision -eq 0){
 $EnvironmentsToUpdate | ForEach-Object {
     $Environment = $_.name
     $applicationFamily = $_.applicationFamily
-
+    Clear-Host
     Write-Host 'Available updates for Environment:' $Environment -ForegroundColor Yellow
 
     $response = Invoke-WebRequest `
@@ -25,7 +25,6 @@ $EnvironmentsToUpdate | ForEach-Object {
     $appsToUpdate = ConvertFrom-Json $response.Content | Select-Object -ExpandProperty value
     $appsToUpdateList = $appsToUpdate | Select-Object -Property appId, name, publisher, version | Sort-Object -Property name | Format-Table | Out-String
 
-    $i = 1
     $NoOfApps = $appsToUpdate.Count
 
     if ($NoOfApps -eq 0) {
@@ -40,7 +39,7 @@ $EnvironmentsToUpdate | ForEach-Object {
         $choices.Add((New-Object Management.Automation.Host.ChoiceDescription -ArgumentList '&Yes'))
         $choices.Add((New-Object Management.Automation.Host.ChoiceDescription -ArgumentList '&No'))
         $decision = $Host.UI.PromptForChoice($title, $question, $choices, 0)
-        Clear-Host
+
         if ($decision -eq 0) {
             if ($useMaintenanceWindows -eq $false) {
                 Write-Host ("You are not using the maintenance window. Updates will start shortly and user sessions may be lost. Continue?") -ForegroundColor Magenta
@@ -65,31 +64,38 @@ $EnvironmentsToUpdate | ForEach-Object {
                             } | ConvertTo-Json) `
                   -Headers @{Authorization=("Bearer $accessToken")} `
                   -ContentType "application/json"
-              
-              $i = $i +1
             }
             # Check update status
-            Do {
-                $response = Invoke-WebRequest `
-                -Method Get `
-                -Uri    "https://api.businesscentral.dynamics.com/admin/$adminVersion/applications/$applicationFamily/environments/$Environment/operations" `
-                -Headers @{Authorization=("Bearer $accessToken")}
-                $OperationsRunning = ConvertFrom-Json $response.Content | Select-Object -ExpandProperty value | where-object {($_.status -eq "scheduled") -or ($_.status -eq "running")} | Select-Object id, status, createdOn, parameters | Format-Table
-                $Number = $OperationsRunning.Count
-                if ( $operationsRunning.count -ne '' ) {
-                    write-host "Installation of $Number extensions remaining..."
-                    Start-Sleep -Seconds 15
-                }
-            }
-            Until( $operationsRunning.count -eq $NoOfApps )
+            if ($useMaintenanceWindows -eq $false) {
+                Do {
+                    #Operations check shows all updates within the update windows. Also the already installed ones. Useless to count.
+                    #$response = Invoke-WebRequest `
+                    #-Method Get `
+                    #-Uri    "https://api.businesscentral.dynamics.com/admin/$adminVersion/applications/$applicationFamily/environments/$Environment/operations" `
+                    #-Headers @{Authorization=("Bearer $accessToken")}
+                    #$OperationsRunning = ConvertFrom-Json $response.Content | Select-Object -ExpandProperty value | where-object {($_.status -eq "scheduled") -or ($_.status -eq "running")} | Select-Object id, status, createdOn, parameters | Format-Table
 
-            # List installed apps
-            Write-Host "Installed apps in $Environment"
-            $response = Invoke-WebRequest `
-                -Method Get `
-                -Uri    "https://api.businesscentral.dynamics.com/admin/$adminVersion/applications/$applicationFamily/environments/$environment/apps" `
-                -Headers @{Authorization=("Bearer $accessToken")}
-            ConvertFrom-Json $response.Content | Select-Object -ExpandProperty Value | Select-Object -Property id, name, publisher, version, state | Format-Table | Out-String | Write-Host
-        } else { Write-Host ("Updates skipped") -ForegroundColor Magenta }      
+                    Start-Sleep -Seconds 15
+                    $response = Invoke-WebRequest `
+                        -Method Get `
+                        -Uri    "https://api.businesscentral.dynamics.com/admin/$adminVersion/applications/$applicationFamily/environments/$Environment/apps/availableUpdates" `
+                        -Headers @{Authorization=("Bearer $accessToken")}
+                    $UpdatesRemaining = ConvertFrom-Json $response.Content | Select-Object -ExpandProperty value
+                    $NoOfUpdatesRemaining = $UpdatesRemaining.count
+                    Write-host "Updates remaining $NoOfUpdatesRemaining"
+                }
+                Until( $NoOfUpdatesRemaining -eq 0 )
+
+                # List installed apps
+                Write-Host "Installed apps in $Environment"
+                $response = Invoke-WebRequest `
+                    -Method Get `
+                    -Uri    "https://api.businesscentral.dynamics.com/admin/$adminVersion/applications/$applicationFamily/environments/$environment/apps" `
+                    -Headers @{Authorization=("Bearer $accessToken")}
+                ConvertFrom-Json $response.Content | Select-Object -ExpandProperty Value | Select-Object -Property id, name, publisher, version, state | Format-Table | Out-String | Write-Host
+            } 
+        } else { 
+                Write-Host ("Updates skipped") -ForegroundColor Magenta 
+        }      
     }
 }

--- a/Cloud/PTE - Pipelines/Install PTE apps.ps1
+++ b/Cloud/PTE - Pipelines/Install PTE apps.ps1
@@ -12,9 +12,10 @@ Install-Module BcContainerHelper -Force
 Import-Module BcContainerHelper -Verbose
 
 #Shared Parameters
-$environment = "SandBox4PSNL" #4PS
+#$environment = "SandBox4PSNL" #4PS
 $environment = "Sandbox" #Standard BC
-$tenant = ""
+$tenant = "4e8a3658-1a43-4a8a-a9d8-02a5c74dbbf5"
+$appfiles = "D:\Apps-Git\Demo\Standaard\OpenData\RISA Support B.V._Open Data Check_24.0.1.0.app"
 
 #4PS Construct
 #$bcContainerHelperConfig.apiBaseUrl = "https://4psconstruct.api.bc.dynamics.com"
@@ -35,25 +36,23 @@ function GetAuthHeaders {
 
 Write-Host -ForegroundColor Cyan 'Authentication complete - we have an access token for Business Central, and it is stored in the $accessToken variable.'
 
-#$appfiles = "D:\OneDrive - RISA Support\Documents\Klanten\BVGO\Powershell\apps\VolkerWessels ICT_VolkerWessels Basis Extensie_23.53.1.1.app"
-$appfiles = "D:\Apps-Git\Demo\Standaard\OpenData\RISA Support B.V._Open Data Check_24.0.0.0.app"
-
-#List Companies
+<#
+companies
 Write-Host "$automationApiUrl/companies"
 $companies = Invoke-RestMethod -Headers (GetAuthHeaders) -Method Get -Uri "$automationApiUrl/companies" -UseBasicParsing
 $companies = $companies.value
 $companies | ForEach-Object {
     $companyId = $_.id
     $companyName = $_.name  
-    Write-Host "Get a list of api calls from company $companyName with id $companyId" -ForegroundColor Green
+    Write-Host "Company $companyName with id $companyId" -ForegroundColor Green
 }
+#>
 
-<#
-# Get possible api calls
 # Standard BC
 # https://api.businesscentral.dynamics.com/v2.0/$tenant/$environment/api/microsoft/automation/v2.0/companies($companyid)/extensions
-$automationApiUrl = "$($bcContainerHelperConfig.apiBaseUrl.TrimEnd('/'))/v2.0/$tenant/$environment/api/microsoft/automation/v2.0" #Get possible api calls
+$automationApiUrl = "$($bcContainerHelperConfig.apiBaseUrl.TrimEnd('/'))/v2.0/$tenant/$environment/api/microsoft/automation/v2.0"
 
+<#
 # 4PS Construct
 # Geen api calls beschikbaar waar extension in beschikbaar zijn. Mogelijk dat dit komt door het verschil in versie van 4PS Construct en Business Central Standard
 # Onderstaande zijn getest, maar hebben geen resultaat opgeleverd
@@ -61,7 +60,8 @@ $automationApiUrl = "$($bcContainerHelperConfig.apiBaseUrl.TrimEnd('/'))/v2.0/$t
 #$automationApiUrl = "$($bcContainerHelperConfig.apiBaseUrl.TrimEnd('/'))/v2.0/$environment/api/microsoft/automation/beta" #Get installed api calls microsoft/automation/beta
 #$automationApiUrl = "$($bcContainerHelperConfig.apiBaseUrl.TrimEnd('/'))/v2.0/$environment/api/microsoft/automate/v1.0" #Get installed api calls microsoft/automate/beta
 #$automationApiUrl = "$($bcContainerHelperConfig.apiBaseUrl.TrimEnd('/'))/v2.0/$environment/api/microsoft/runtime/beta" #Get installed api calls microsoft/automation/beta
-
+#>
+<#
 $Contents = Invoke-WebRequest -Headers (GetAuthHeaders) -Method Get -Uri "$automationApiUrl"
 (ConvertFrom-Json $Contents.Content).value | Sort-Object -Property DisplayName
 #>
@@ -76,151 +76,135 @@ $companies | ForEach-Object {
     $getExtensions = Invoke-WebRequest -Headers (GetAuthHeaders) -Method Get -Uri "$automationApiUrl/companies($companyId)/extensions"
     $extensions = (ConvertFrom-Json $getExtensions.Content).value | Sort-Object -Property DisplayName | Where-Object {($_.PublishedAs -EQ ' PTE')}
     (ConvertFrom-Json $getExtensions.Content).value | Sort-Object -Property DisplayName | Select-Object -Property id,DisplayName,versionMajor,versionMinor,versionBuild,versionRevision,publisher, isInstalled, PublishedAs | Where-Object {($_.PublishedAs -EQ ' PTE')} | Format-Table -AutoSize
-}      
-Pause
-Write-Host "Publishing and installing apps" -ForegroundColor Green
-$body = @{"schedule" = "Current Version"}
-$body."SchemaSyncMode" = "Force Sync"
 
-$appDep = $extensions | Where-Object { $_.DisplayName -eq 'Application' }
-$appDepVer = [System.Version]"$($appDep.versionMajor).$($appDep.versionMinor).$($appDep.versionBuild).$($appDep.versionRevision)"
-if ($appDepVer -ge [System.Version]"23.0.0.0") {
-    if ($schemaSyncMode -eq 'Force') {
-        $body."SchemaSyncMode" = "Force Sync"
-    }
-    else {
-        $body."SchemaSyncMode" = "Add"
-    }
-}
-else {
-    if ($schemaSyncMode -eq 'Force') {
-        throw 'SchemaSyncMode Force is not supported before version 21.2'
-    }
-}
-if($schedule) {
-    $body."schedule" = $schedule
-}
-
-$ifMatchHeader = @{ "If-Match" = '*'}
-$jsonHeader = @{ "Content-Type" = 'application/json'}
-$streamHeader = @{ "Content-Type" = 'application/octet-stream'}
-try {
-    Sort-AppFilesByDependencies -appFiles $appFiles -excludeRuntimePackages | ForEach-Object {
-        Write-Host -NoNewline "$([System.IO.Path]::GetFileName($_)) - "
-        $appJson = Get-AppJsonFromAppFile -appFile $_
+    Write-Host "Publishing and installing apps" -ForegroundColor Green
+    $body = @{"schedule" = "Current Version"}
+    $body."SchemaSyncMode" = "Force Sync"
+    $ifMatchHeader = @{ "If-Match" = '*'}
+    $jsonHeader = @{ "Content-Type" = 'application/json'}
+    $streamHeader = @{ "Content-Type" = 'application/octet-stream'}
+    try {
+        Sort-AppFilesByDependencies -appFiles $appFiles -excludeRuntimePackages | ForEach-Object {
+            Write-Host -NoNewline "$([System.IO.Path]::GetFileName($_)) - "
+            $appJson = Get-AppJsonFromAppFile -appFile $_
+            
+            $existingApp = $extensions | Where-Object { $_.id -eq $appJson.id -and $_.isInstalled }
         
-        $existingApp = $extensions | Where-Object { $_.id -eq $appJson.id -and $_.isInstalled }
-
-        if ($existingApp) {
-            if ($existingApp.isInstalled) {
-                $existingVersion = [System.Version]"$($existingApp.versionMajor).$($existingApp.versionMinor).$($existingApp.versionBuild).$($existingApp.versionRevision)"
-                if ($existingVersion -ge $appJson.version) {
-                    Write-Host "already installed"
+            if ($existingApp) {
+                if ($existingApp.isInstalled) {
+                    $existingVersion = [System.Version]"$($existingApp.versionMajor).$($existingApp.versionMinor).$($existingApp.versionBuild).$($existingApp.versionRevision)"
+                    if ($existingVersion -ge $appJson.version) {
+                        Write-Host "already installed"
+                    }
+                    else {
+                        Write-Host @newLine "upgrading"
+                        $existingApp = $null
+                    }
                 }
                 else {
-                    Write-Host @newLine "upgrading"
+                    Write-Host @newLine "installing"
                     $existingApp = $null
                 }
             }
             else {
-                Write-Host @newLine "installing"
-                $existingApp = $null
+                Write-Host @newLine "publishing and installing"
             }
-        }
-        else {
-            Write-Host @newLine "publishing and installing"
-        }
-
-        if (!$existingApp) {
-            $extensionUpload = (Invoke-RestMethod -Method Get -Uri "$automationApiUrl/companies($companyId)/extensionUpload" -Headers (GetAuthHeaders)).value
-            Write-Host @newLine "."
-            if ($extensionUpload -and $extensionUpload.systemId) {
-                $extensionUpload = Invoke-RestMethod `
+        
+            if (!$existingApp) {
+                $extensionUpload = (Invoke-RestMethod -Method Get -Uri "$automationApiUrl/companies($companyId)/extensionUpload" -Headers (GetAuthHeaders)).value
+                Write-Host @newLine "."
+                if ($extensionUpload -and $extensionUpload.systemId) {
+                    $extensionUpload = Invoke-RestMethod `
+                        -Method Patch `
+                        -Uri "$automationApiUrl/companies($companyId)/extensionUpload($($extensionUpload.systemId))" `
+                        -Headers ((GetAuthHeaders) + $ifMatchHeader + $jsonHeader) `
+                        -Body ($body | ConvertTo-Json -Compress)
+                }
+                else {
+                    $ExtensionUpload = Invoke-RestMethod `
+                        -Method Post `
+                        -Uri "$automationApiUrl/companies($companyId)/extensionUpload" `
+                        -Headers ((GetAuthHeaders) + $jsonHeader) `
+                        -Body ($body | ConvertTo-Json -Compress)
+                }
+                Write-Host @newLine "."
+                if ($null -eq $extensionUpload.systemId) {
+                    throw "Unable to upload extension"
+                }
+                $fileBody = [System.IO.File]::ReadAllBytes($_)
+                Invoke-RestMethod `
                     -Method Patch `
-                    -Uri "$automationApiUrl/companies($companyId)/extensionUpload($($extensionUpload.systemId))" `
-                    -Headers ((GetAuthHeaders) + $ifMatchHeader + $jsonHeader) `
-                    -Body ($body | ConvertTo-Json -Compress)
-            }
-            else {
-                $ExtensionUpload = Invoke-RestMethod `
+                    -Uri $extensionUpload.'extensionContent@odata.mediaEditLink' `
+                    -Headers ((GetAuthHeaders) + $ifMatchHeader + $streamHeader) `
+                    -Body $fileBody | Out-Null
+                Write-Host @newLine "."    
+                Invoke-RestMethod `
                     -Method Post `
-                    -Uri "$automationApiUrl/companies($companyId)/extensionUpload" `
-                    -Headers ((GetAuthHeaders) + $jsonHeader) `
-                    -Body ($body | ConvertTo-Json -Compress)
-            }
-            Write-Host @newLine "."
-            if ($null -eq $extensionUpload.systemId) {
-                throw "Unable to upload extension"
-            }
-            $fileBody = [System.IO.File]::ReadAllBytes($_)
-            Invoke-RestMethod `
-                -Method Patch `
-                -Uri $extensionUpload.'extensionContent@odata.mediaEditLink' `
-                -Headers ((GetAuthHeaders) + $ifMatchHeader + $streamHeader) `
-                -Body $fileBody | Out-Null
-            Write-Host @newLine "."    
-            Invoke-RestMethod `
-                -Method Post `
-                -Uri "$automationApiUrl/companies($companyId)/extensionUpload($($extensionUpload.systemId))/Microsoft.NAV.upload" `
-                -Headers ((GetAuthHeaders) + $ifMatchHeader) | Out-Null
-            Write-Host @newLine "."    
-            $completed = $false
-            $errCount = 0
-            $sleepSeconds = 30
-            while (!$completed)
-            {
-                Start-Sleep -Seconds $sleepSeconds
-                try {
-                    $extensionDeploymentStatusResponse = Invoke-WebRequest -Headers (GetAuthHeaders) -Method Get -Uri "$automationApiUrl/companies($companyId)/extensionDeploymentStatus" -UseBasicParsing
-                    $extensionDeploymentStatuses = (ConvertFrom-Json $extensionDeploymentStatusResponse.Content).value
-
-                    $completed = $true
-                    $extensionDeploymentStatuses | Where-Object { $_.publisher -eq $appJson.publisher -and $_.name -eq $appJson.name -and $_.appVersion -eq $appJson.version } | % {
-                        if ($_.status -eq "InProgress") {
-                            Write-Host @newLine "."
-                            $completed = $false
+                    -Uri "$automationApiUrl/companies($companyId)/extensionUpload($($extensionUpload.systemId))/Microsoft.NAV.upload" `
+                    -Headers ((GetAuthHeaders) + $ifMatchHeader) | Out-Null
+                Write-Host @newLine "."    
+                $completed = $false
+                $errCount = 0
+                $sleepSeconds = 30
+                while (!$completed)
+                {
+                    Start-Sleep -Seconds $sleepSeconds
+                    try {
+                        $extensionDeploymentStatusResponse = Invoke-WebRequest -Headers (GetAuthHeaders) -Method Get -Uri "$automationApiUrl/companies($companyId)/extensionDeploymentStatus" -UseBasicParsing
+                        $extensionDeploymentStatuses = (ConvertFrom-Json $extensionDeploymentStatusResponse.Content).value
+                    
+                        $completed = $true
+                        $extensionDeploymentStatuses | Where-Object { $_.publisher -eq $appJson.publisher -and $_.name -eq $appJson.name -and $_.appVersion -eq $appJson.version } | % {
+                            if ($_.status -eq "InProgress") {
+                                Write-Host @newLine "."
+                                $completed = $false
+                            }
+                            elseif ($_.Status -eq "Unknown") {
+                                throw "Unknown Error"
+                            }
+                            elseif ($_.Status -ne "Completed") {
+                                $errCount = 5
+                                throw $_.status
+                            }
                         }
-                        elseif ($_.Status -eq "Unknown") {
-                            throw "Unknown Error"
-                        }
-                        elseif ($_.Status -ne "Completed") {
-                            $errCount = 5
-                            throw $_.status
-                        }
+                        $errCount = 0
+                        $sleepSeconds = 5
                     }
-                    $errCount = 0
-                    $sleepSeconds = 5
-                }
-                catch {
-                    if ($errCount++ -gt 4) {
-                        Write-Host $_.Exception.Message
-                        throw "Unable to publish app. Please open the Extension Deployment Status Details page in Business Central to see the detailed error message."
+                    catch {
+                        if ($errCount++ -gt 4) {
+                            Write-Host $_.Exception.Message
+                            throw "Unable to publish app. Please open the Extension Deployment Status Details page in Business Central to see the detailed error message."
+                        }
+                        $sleepSeconds += $sleepSeconds
+                        $completed = $false
                     }
-                    $sleepSeconds += $sleepSeconds
-                    $completed = $false
                 }
-            }
-            if ($completed) {
-                Write-Host "completed"
+                if ($completed) {
+                    Write-Host "completed"
+                }
             }
         }
     }
-}
-catch [System.Net.WebException],[System.Net.Http.HttpRequestException] {
-    Write-Host "ERROR $($_.Exception.Message)"
-    Write-Host $_.ScriptStackTrace
-    throw (GetExtendedErrorMessage $_)
-}
-catch {
-    Write-Host "ERROR: $($_.Exception.Message) [$($_.Exception.GetType().FullName)]"
-    TrackException -telemetryScope $telemetryScope -errorRecord $_
-    throw
-}
-finally {
-    $getExtensions = Invoke-WebRequest -Headers (GetAuthHeaders) -Method Get -Uri "$automationApiUrl/companies($companyId)/extensions" -UseBasicParsing
-    $extensions = (ConvertFrom-Json $getExtensions.Content).value | Sort-Object -Property DisplayName | Where-Object {($_.PublishedAs -EQ ' PTE')}
-    if (Test-Path $appFolder) {
-        Remove-Item $appFolder -Recurse -Force -ErrorAction SilentlyContinue
+    catch [System.Net.WebException],[System.Net.Http.HttpRequestException] {
+        Write-Host "ERROR $($_.Exception.Message)"
+        Write-Host $_.ScriptStackTrace
+        throw (GetExtendedErrorMessage $_)
     }
-    TrackTrace -telemetryScope $telemetryScope
+    catch {
+        Write-Host "ERROR: $($_.Exception.Message) [$($_.Exception.GetType().FullName)]"
+        TrackException -telemetryScope $telemetryScope -errorRecord $_
+        throw
+    }
+    finally {
+        $getExtensions = Invoke-WebRequest -Headers (GetAuthHeaders) -Method Get -Uri "$automationApiUrl/companies($companyId)/extensions" -UseBasicParsing
+        $extensions = (ConvertFrom-Json $getExtensions.Content).value | Sort-Object -Property DisplayName | Where-Object {($_.PublishedAs -EQ ' PTE')}
+        (ConvertFrom-Json $getExtensions.Content).value | Sort-Object -Property DisplayName | Select-Object -Property id,DisplayName,versionMajor,versionMinor,versionBuild,versionRevision,publisher, isInstalled, PublishedAs | Where-Object {($_.PublishedAs -EQ ' PTE')} | Format-Table -AutoSize
+        TrackTrace -telemetryScope $telemetryScope
+
+        #Unpublish uninstalled extensions does not seem possible         
+
+        Write-Host "Finished publishing and installing apps" -ForegroundColor Green
+    }
 }
+
+

--- a/Cloud/PTE - Pipelines/Install PTE apps.ps1
+++ b/Cloud/PTE - Pipelines/Install PTE apps.ps1
@@ -1,20 +1,226 @@
 
+# Script Publish-PerTenantExtensionApps.ps1 is modified to use only for PTE extensions and testing with 4PS Construct
+# Publish-PerTenantExtensionApps `
+#    -bcAuthContext $authContext `
+#    -environment $environment `
+#    -appFiles $apps 
+#
+# It works for Business Central Standard, but not for 4PS Construct. Probably because of the different API calls and the different way of handling the apps in
+# version 23.51 of 4PS Construct and version 24.4 of Business Central Standard.
+
+Install-Module BcContainerHelper -Force
 Import-Module BcContainerHelper -Verbose
 
 #Shared Parameters
-$adminVersion = "V2.21"
-$applicationFamily = "4PSConstruct"
+$environment = "SandBox4PSNL" #4PS
+$environment = "Sandbox" #Standard BC
+$tenant = "4e8a3658-1a43-4a8a-a9d8-02a5c74dbbf5"
 
-$bcContainerHelperConfig.apiBaseUrl = "https://4psconstruct.api.bc.dynamics.com"
-$bcContainerHelperConfig.baseUrl = "https://4psconstruct.bc.dynamics.com"
+#4PS Construct
+#$bcContainerHelperConfig.apiBaseUrl = "https://4psconstruct.api.bc.dynamics.com"
+#$bcContainerHelperConfig.baseUrl = "https://4psconstruct.bc.dynamics.com"
+
+#Standard BC
+#Not required to set these values but after changing the values, the script will work for 4PS Construct but not anymore for Standard BC
+$bcContainerHelperConfig.apiBaseUrl = "https://api.businesscentral.dynamics.com"
+$bcContainerHelperConfig.baseUrl = "https://businesscentral.dynamics.com"
 
 ######### Login #############
 $authContext = New-BcAuthContext -includeDeviceLogin
 $accessToken = $authContext.AccessToken
+
+function GetAuthHeaders {
+    return @{ "Authorization" = "Bearer $($accessToken)" }
+}
+
 Write-Host -ForegroundColor Cyan 'Authentication complete - we have an access token for Business Central, and it is stored in the $accessToken variable.'
 
-$apps = "https://businesscentralapps.azureedge.net/githubhelloworld/latest/apps.zip"
-Publish-PerTenantExtensionApps `
-    -bcAuthContext $authContext `
-    -environment $environment `
-    -appFiles $apps
+#$appfiles = "D:\OneDrive - RISA Support\Documents\Klanten\BVGO\Powershell\apps\VolkerWessels ICT_VolkerWessels Basis Extensie_23.53.1.1.app"
+$appfiles = "D:\Apps-Git\Demo\Standaard\OpenData\RISA Support B.V._Open Data Check_24.0.0.0.app"
+
+#List Companies
+Write-Host "$automationApiUrl/companies"
+$companies = Invoke-RestMethod -Headers (GetAuthHeaders) -Method Get -Uri "$automationApiUrl/companies" -UseBasicParsing
+$companies = $companies.value
+$companies | ForEach-Object {
+    $companyId = $_.id
+    $companyName = $_.name  
+    Write-Host "Get a list of api calls from company $companyName with id $companyId" -ForegroundColor Green
+}
+
+<#
+# Get possible api calls
+# Standard BC
+# https://api.businesscentral.dynamics.com/v2.0/$tenant/$environment/api/microsoft/automation/v2.0/companies($companyid)/extensions
+$automationApiUrl = "$($bcContainerHelperConfig.apiBaseUrl.TrimEnd('/'))/v2.0/$tenant/$environment/api/microsoft/automation/v2.0" #Get possible api calls
+
+# 4PS Construct
+# Geen api calls beschikbaar waar extension in beschikbaar zijn. Mogelijk dat dit komt door het verschil in versie van 4PS Construct en Business Central Standard
+# Onderstaande zijn getest, maar hebben geen resultaat opgeleverd
+#$automationApiUrl = "$($bcContainerHelperConfig.apiBaseUrl.TrimEnd('/'))/v2.0/$environment/api/microsoft/admin/beta" #Get installed api calls microsoft/admin/beta
+#$automationApiUrl = "$($bcContainerHelperConfig.apiBaseUrl.TrimEnd('/'))/v2.0/$environment/api/microsoft/automation/beta" #Get installed api calls microsoft/automation/beta
+#$automationApiUrl = "$($bcContainerHelperConfig.apiBaseUrl.TrimEnd('/'))/v2.0/$environment/api/microsoft/automate/v1.0" #Get installed api calls microsoft/automate/beta
+#$automationApiUrl = "$($bcContainerHelperConfig.apiBaseUrl.TrimEnd('/'))/v2.0/$environment/api/microsoft/runtime/beta" #Get installed api calls microsoft/automation/beta
+
+$Contents = Invoke-WebRequest -Headers (GetAuthHeaders) -Method Get -Uri "$automationApiUrl"
+(ConvertFrom-Json $Contents.Content).value | Sort-Object -Property DisplayName
+#>
+
+#Get PTE Extensions per company
+$companies = Invoke-RestMethod -Headers (GetAuthHeaders) -Method Get -Uri "$automationApiUrl/companies" -UseBasicParsing
+$companies = $companies.value
+$companies | ForEach-Object {
+    $companyId = $_.id
+    $companyName = $_.name  
+    Write-Host "Extensions from company $companyName with id $companyId" -ForegroundColor Green
+    $getExtensions = Invoke-WebRequest -Headers (GetAuthHeaders) -Method Get -Uri "$automationApiUrl/companies($companyId)/extensions"
+    $extensions = (ConvertFrom-Json $getExtensions.Content).value | Sort-Object -Property DisplayName | Where-Object {($_.PublishedAs -EQ ' PTE')}
+    (ConvertFrom-Json $getExtensions.Content).value | Sort-Object -Property DisplayName | Select-Object -Property id,DisplayName,versionMajor,versionMinor,versionBuild,versionRevision,publisher, isInstalled, PublishedAs | Where-Object {($_.PublishedAs -EQ ' PTE')} | Format-Table -AutoSize
+}      
+Pause
+Write-Host "Publishing and installing apps" -ForegroundColor Green
+$body = @{"schedule" = "Current Version"}
+$body."SchemaSyncMode" = "Force Sync"
+
+$appDep = $extensions | Where-Object { $_.DisplayName -eq 'Application' }
+$appDepVer = [System.Version]"$($appDep.versionMajor).$($appDep.versionMinor).$($appDep.versionBuild).$($appDep.versionRevision)"
+if ($appDepVer -ge [System.Version]"23.0.0.0") {
+    if ($schemaSyncMode -eq 'Force') {
+        $body."SchemaSyncMode" = "Force Sync"
+    }
+    else {
+        $body."SchemaSyncMode" = "Add"
+    }
+}
+else {
+    if ($schemaSyncMode -eq 'Force') {
+        throw 'SchemaSyncMode Force is not supported before version 21.2'
+    }
+}
+if($schedule) {
+    $body."schedule" = $schedule
+}
+
+$ifMatchHeader = @{ "If-Match" = '*'}
+$jsonHeader = @{ "Content-Type" = 'application/json'}
+$streamHeader = @{ "Content-Type" = 'application/octet-stream'}
+try {
+    Sort-AppFilesByDependencies -appFiles $appFiles -excludeRuntimePackages | ForEach-Object {
+        Write-Host -NoNewline "$([System.IO.Path]::GetFileName($_)) - "
+        $appJson = Get-AppJsonFromAppFile -appFile $_
+        
+        $existingApp = $extensions | Where-Object { $_.id -eq $appJson.id -and $_.isInstalled }
+
+        if ($existingApp) {
+            if ($existingApp.isInstalled) {
+                $existingVersion = [System.Version]"$($existingApp.versionMajor).$($existingApp.versionMinor).$($existingApp.versionBuild).$($existingApp.versionRevision)"
+                if ($existingVersion -ge $appJson.version) {
+                    Write-Host "already installed"
+                }
+                else {
+                    Write-Host @newLine "upgrading"
+                    $existingApp = $null
+                }
+            }
+            else {
+                Write-Host @newLine "installing"
+                $existingApp = $null
+            }
+        }
+        else {
+            Write-Host @newLine "publishing and installing"
+        }
+
+        if (!$existingApp) {
+            $extensionUpload = (Invoke-RestMethod -Method Get -Uri "$automationApiUrl/companies($companyId)/extensionUpload" -Headers (GetAuthHeaders)).value
+            Write-Host @newLine "."
+            if ($extensionUpload -and $extensionUpload.systemId) {
+                $extensionUpload = Invoke-RestMethod `
+                    -Method Patch `
+                    -Uri "$automationApiUrl/companies($companyId)/extensionUpload($($extensionUpload.systemId))" `
+                    -Headers ((GetAuthHeaders) + $ifMatchHeader + $jsonHeader) `
+                    -Body ($body | ConvertTo-Json -Compress)
+            }
+            else {
+                $ExtensionUpload = Invoke-RestMethod `
+                    -Method Post `
+                    -Uri "$automationApiUrl/companies($companyId)/extensionUpload" `
+                    -Headers ((GetAuthHeaders) + $jsonHeader) `
+                    -Body ($body | ConvertTo-Json -Compress)
+            }
+            Write-Host @newLine "."
+            if ($null -eq $extensionUpload.systemId) {
+                throw "Unable to upload extension"
+            }
+            $fileBody = [System.IO.File]::ReadAllBytes($_)
+            Invoke-RestMethod `
+                -Method Patch `
+                -Uri $extensionUpload.'extensionContent@odata.mediaEditLink' `
+                -Headers ((GetAuthHeaders) + $ifMatchHeader + $streamHeader) `
+                -Body $fileBody | Out-Null
+            Write-Host @newLine "."    
+            Invoke-RestMethod `
+                -Method Post `
+                -Uri "$automationApiUrl/companies($companyId)/extensionUpload($($extensionUpload.systemId))/Microsoft.NAV.upload" `
+                -Headers ((GetAuthHeaders) + $ifMatchHeader) | Out-Null
+            Write-Host @newLine "."    
+            $completed = $false
+            $errCount = 0
+            $sleepSeconds = 30
+            while (!$completed)
+            {
+                Start-Sleep -Seconds $sleepSeconds
+                try {
+                    $extensionDeploymentStatusResponse = Invoke-WebRequest -Headers (GetAuthHeaders) -Method Get -Uri "$automationApiUrl/companies($companyId)/extensionDeploymentStatus" -UseBasicParsing
+                    $extensionDeploymentStatuses = (ConvertFrom-Json $extensionDeploymentStatusResponse.Content).value
+
+                    $completed = $true
+                    $extensionDeploymentStatuses | Where-Object { $_.publisher -eq $appJson.publisher -and $_.name -eq $appJson.name -and $_.appVersion -eq $appJson.version } | % {
+                        if ($_.status -eq "InProgress") {
+                            Write-Host @newLine "."
+                            $completed = $false
+                        }
+                        elseif ($_.Status -eq "Unknown") {
+                            throw "Unknown Error"
+                        }
+                        elseif ($_.Status -ne "Completed") {
+                            $errCount = 5
+                            throw $_.status
+                        }
+                    }
+                    $errCount = 0
+                    $sleepSeconds = 5
+                }
+                catch {
+                    if ($errCount++ -gt 4) {
+                        Write-Host $_.Exception.Message
+                        throw "Unable to publish app. Please open the Extension Deployment Status Details page in Business Central to see the detailed error message."
+                    }
+                    $sleepSeconds += $sleepSeconds
+                    $completed = $false
+                }
+            }
+            if ($completed) {
+                Write-Host "completed"
+            }
+        }
+    }
+}
+catch [System.Net.WebException],[System.Net.Http.HttpRequestException] {
+    Write-Host "ERROR $($_.Exception.Message)"
+    Write-Host $_.ScriptStackTrace
+    throw (GetExtendedErrorMessage $_)
+}
+catch {
+    Write-Host "ERROR: $($_.Exception.Message) [$($_.Exception.GetType().FullName)]"
+    TrackException -telemetryScope $telemetryScope -errorRecord $_
+    throw
+}
+finally {
+    $getExtensions = Invoke-WebRequest -Headers (GetAuthHeaders) -Method Get -Uri "$automationApiUrl/companies($companyId)/extensions" -UseBasicParsing
+    $extensions = (ConvertFrom-Json $getExtensions.Content).value | Sort-Object -Property DisplayName | Where-Object {($_.PublishedAs -EQ ' PTE')}
+    if (Test-Path $appFolder) {
+        Remove-Item $appFolder -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    TrackTrace -telemetryScope $telemetryScope
+}

--- a/Cloud/PTE - Pipelines/Install PTE apps.ps1
+++ b/Cloud/PTE - Pipelines/Install PTE apps.ps1
@@ -14,7 +14,7 @@ Import-Module BcContainerHelper -Verbose
 #Shared Parameters
 $environment = "SandBox4PSNL" #4PS
 $environment = "Sandbox" #Standard BC
-$tenant = "4e8a3658-1a43-4a8a-a9d8-02a5c74dbbf5"
+$tenant = ""
 
 #4PS Construct
 #$bcContainerHelperConfig.apiBaseUrl = "https://4psconstruct.api.bc.dynamics.com"

--- a/Cloud/PTE - Pipelines/Run Codeunit.ps1
+++ b/Cloud/PTE - Pipelines/Run Codeunit.ps1
@@ -2,6 +2,18 @@
 # Script to run a codeunit in Business Central using a webservice  
 # The script will first authenticate with Business Central and then run the codeunit
 # The script will output the result of the codeunit to the console
+# The script is written in PowerShell and uses the BcContainerHelper module for authentication
+#
+# It uses a codeunit with a webservice called UseAPICodeunit with a procedure called PingPong with the following content:
+# codeunit 50500 APICodeunit
+# {
+#     procedure PingPong(pingText: Text): Text
+#     begin
+#         if pingText = 'ping' then
+#             exit('pong');
+#         exit('');
+#     end;
+# }
 
 Install-Module BcContainerHelper -Force
 Import-Module BcContainerHelper -Verbose

--- a/Cloud/PTE - Pipelines/Run Codeunit.ps1
+++ b/Cloud/PTE - Pipelines/Run Codeunit.ps1
@@ -1,0 +1,46 @@
+﻿
+# Script to run a codeunit in Business Central using a webservice  
+# The script will first authenticate with Business Central and then run the codeunit
+# The script will output the result of the codeunit to the console
+
+Install-Module BcContainerHelper -Force
+Import-Module BcContainerHelper -Verbose
+
+#Shared Parameters
+$environment = "SandBox4PSNL" #4PS
+#$environment = "Sandbox" #Standard BC
+
+#4PS Construct
+$bcContainerHelperConfig.apiBaseUrl = "https://4psconstruct.api.bc.dynamics.com"
+$bcContainerHelperConfig.baseUrl = "https://4psconstruct.bc.dynamics.com"
+
+#Standard BC
+#Not required to set these values but after changing the values, the script will work for 4PS Construct but not anymore for Standard BC
+#$bcContainerHelperConfig.apiBaseUrl = "https://api.businesscentral.dynamics.com"
+#$bcContainerHelperConfig.baseUrl = "https://businesscentral.dynamics.com"
+
+######### Login #############
+$authContext = New-BcAuthContext -includeDeviceLogin
+$accessToken = $authContext.AccessToken
+
+function GetAuthHeaders {
+    return @{ "Authorization" = "Bearer $($accessToken)" }
+}
+
+Write-Host -ForegroundColor Cyan 'Authentication complete - we have an access token for Business Central, and it is stored in the $accessToken variable.'
+
+# Standard BC
+# https://api.businesscentral.dynamics.com/v2.0/$environment/ODataV4/<Webservicename>_<Procedure>
+# 4PS Construct
+# https://4psconstruct.api.bc.dynamics.com/v2.0/$environment/ODataV4/<Webservicename>_<Procedure>
+$automationApiUrl = "$($bcContainerHelperConfig.apiBaseUrl.TrimEnd('/'))/v2.0/$environment/ODataV4/UseAPICodeunit_PingPong"
+
+Invoke-WebRequest `
+    -Method Post `
+    -Uri    $automationApiUrl `
+    -Body   (@{
+                 pingText = "ping" #Input parameter
+              } | ConvertTo-Json) `
+    -Headers @{Authorization=("Bearer $accessToken")} `
+    -ContentType "application/json"
+


### PR DESCRIPTION
Now it is possible to install customization apps over multiple environments with the same command from powershell. Also running a codeunit, publiished as a webservice can be executed using BcContainerHelper for authentication. BcContainerHelper uses devicelogin and is only possible for someone with at least Business Central Administrator permissions.